### PR TITLE
[1.20.1] Update dependencies, English translations, and reference names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,8 @@ repositories {
 dependencies {
     minecraft "net.minecraftforge:forge:${mc_version}-${forge_version}"
 
-    implementation fg.deobf("com.teamabnormals:blueprint:${mc_version}-${blueprint}")
+    implementation fg.deobf("curse.maven:blueprint-382216:${blueprint_id}")
+    implementation fg.deobf("curse.maven:gallery-1173553:${gallery_id}")
     implementation fg.deobf("curse.maven:neapolitan-382016:${neapolitan_id}")
     implementation fg.deobf("curse.maven:atmospheric-362393:${atmospheric_id}")
     runtimeOnly fg.deobf("curse.maven:jei-238222:5846810")

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,13 +2,14 @@ org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
 mod_id = peculiars
-mod_version = 5.0.0
+mod_version = 5.0.1
 mc_version = 1.20.1
 forge_version = 47.1.3
 
 mappingsChannel = parchment
 parchment_version = 2023.09.03
 
-blueprint = 7.1.0
-neapolitan_id = 5296594
-atmospheric_id = 6057624
+blueprint_id = 6408581
+gallery_id = 6321203
+neapolitan_id = 6248885
+atmospheric_id = 6393127

--- a/src/main/java/com/cosmicgelatin/peculiars/core/PeculiarsConfig.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/PeculiarsConfig.java
@@ -16,8 +16,8 @@ public class PeculiarsConfig {
         Common(ForgeConfigSpec.Builder builder) {
             builder.push("atmospheric");
             this.enableAtmosphericFood = builder.comment("If Atmospheric-flavored foods' recipes are enabled; defaults to true").define("EnableAtmosphericFood", true);
-            this.disableSorbet = builder.comment("If passionfruit sorbet recipe is disabled; defaults to true").define("DisableSorbet", true);
-            this.tartSpitting = builder.comment("If passionfruit tart gives spitting effect; defaults to true").define("TartSpitting", true);
+            this.disableSorbet = builder.comment("If passion fruit sorbet recipe is disabled; defaults to true").define("DisableSorbet", true);
+            this.tartSpitting = builder.comment("If passion fruit tart gives spitting effect; defaults to true").define("TartSpitting", true);
         }
     }
 

--- a/src/main/java/com/cosmicgelatin/peculiars/core/data/server/tags/PeculiarsItemTagsProvider.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/data/server/tags/PeculiarsItemTagsProvider.java
@@ -24,7 +24,7 @@ public class PeculiarsItemTagsProvider extends ItemTagsProvider {
         tag(NeapolitanItemTags.ICE_CREAM).add(
                 PeculiarsItems.YUCCA_ICE_CREAM.get(),
                 PeculiarsItems.ALOE_ICE_CREAM.get(),
-                PeculiarsItems.PASSIONFRUIT_ICE_CREAM.get()
+                PeculiarsItems.PASSION_FRUIT_ICE_CREAM.get()
         );
     }
 }

--- a/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsCauldronInteractions.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsCauldronInteractions.java
@@ -11,13 +11,13 @@ import net.minecraft.core.cauldron.CauldronInteraction;
 public class PeculiarsCauldronInteractions {
     public static BlueprintCauldronInteraction YUCCA_MILKSHAKE = BlueprintCauldronInteraction.register(Peculiars.modPrefix("yucca_milkshake"), CauldronInteraction.newInteractionMap());
     public static BlueprintCauldronInteraction ALOE_MILKSHAKE = BlueprintCauldronInteraction.register(Peculiars.modPrefix("aloe_milkshake"), CauldronInteraction.newInteractionMap());
-    public static BlueprintCauldronInteraction PASSIONFRUIT_MILKSHAKE = BlueprintCauldronInteraction.register(Peculiars.modPrefix("passionfruit_milkshake"), CauldronInteraction.newInteractionMap());
+    public static BlueprintCauldronInteraction PASSION_FRUIT_MILKSHAKE = BlueprintCauldronInteraction.register(Peculiars.modPrefix("passion_fruit_milkshake"), CauldronInteraction.newInteractionMap());
 
     public static void registerCauldronInteractions() {
         if (NeapolitanConfig.COMMON.milkshakeCauldrons.get()) {
             NeapolitanCauldronInteractions.addMilkshakeInteractions(PeculiarsItems.YUCCA_MILKSHAKE.get(), PeculiarsBlocks.YUCCA_MILKSHAKE_CAULDRON.get(), PeculiarsItems.YUCCA_ICE_CREAM.get(), YUCCA_MILKSHAKE.map());
             NeapolitanCauldronInteractions.addMilkshakeInteractions(PeculiarsItems.ALOE_MILKSHAKE.get(), PeculiarsBlocks.ALOE_MILKSHAKE_CAULDRON.get(), PeculiarsItems.ALOE_ICE_CREAM.get(), ALOE_MILKSHAKE.map());
-            NeapolitanCauldronInteractions.addMilkshakeInteractions(PeculiarsItems.PASSIONFRUIT_MILKSHAKE.get(), PeculiarsBlocks.PASSION_FRUIT_MILKSHAKE_CAULDRON.get(), PeculiarsItems.PASSIONFRUIT_ICE_CREAM.get(), PASSIONFRUIT_MILKSHAKE.map());
+            NeapolitanCauldronInteractions.addMilkshakeInteractions(PeculiarsItems.PASSION_FRUIT_MILKSHAKE.get(), PeculiarsBlocks.PASSION_FRUIT_MILKSHAKE_CAULDRON.get(), PeculiarsItems.PASSION_FRUIT_ICE_CREAM.get(), PASSION_FRUIT_MILKSHAKE.map());
         }
     }
 }

--- a/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsCompat.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsCompat.java
@@ -11,6 +11,6 @@ public class PeculiarsCompat {
 
         DataUtil.registerCompostable(PeculiarsItems.YUCCA_CAKE.get(), 1.0F);
         DataUtil.registerCompostable(PeculiarsItems.ALOE_CAKE.get(), 1.0F);
-        DataUtil.registerCompostable(PeculiarsItems.PASSIONFRUIT_CAKE.get(), 1.0F);
+        DataUtil.registerCompostable(PeculiarsItems.PASSION_FRUIT_CAKE.get(), 1.0F);
     }
 }

--- a/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsCreativeModTabContents.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsCreativeModTabContents.java
@@ -18,7 +18,7 @@ public class PeculiarsCreativeModTabContents {
                 .addItems(
                         YUCCA_ICE_CREAM, YUCCA_MILKSHAKE, YUCCA_FUDGE, YUCCA_CAKE,
                         ALOE_ICE_CREAM, ALOE_MILKSHAKE, ALOE_JELLY_SLICE, ALOE_BERRY_SMOOTHIE, ALOE_CAKE,
-                        PASSIONFRUIT_ICE_CREAM, PASSIONFRUIT_MILKSHAKE, PASSIONFRUIT_CAKE, TROPICAL_SALAD
+                        PASSION_FRUIT_ICE_CREAM, PASSION_FRUIT_MILKSHAKE, PASSION_FRUIT_CAKE, TROPICAL_SALAD
                 )
                 .tab(CreativeModeTabs.BUILDING_BLOCKS)
                 .addItems(

--- a/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsEvents.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/other/PeculiarsEvents.java
@@ -83,7 +83,7 @@ public class PeculiarsEvents {
                 TradeUtil.addVillagerTrades(event, TradeUtil.EXPERT,
                         new TradeUtil.BlueprintTrade(3, PeculiarsItems.ALOE_CAKE.get(), 1, 12, 15));
                 TradeUtil.addVillagerTrades(event, TradeUtil.EXPERT,
-                        new TradeUtil.BlueprintTrade(3, PeculiarsItems.PASSIONFRUIT_CAKE.get(), 1, 12, 15));
+                        new TradeUtil.BlueprintTrade(3, PeculiarsItems.PASSION_FRUIT_CAKE.get(), 1, 12, 15));
             }
         }
     }

--- a/src/main/java/com/cosmicgelatin/peculiars/core/registry/PeculiarsBlocks.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/registry/PeculiarsBlocks.java
@@ -23,9 +23,9 @@ public class PeculiarsBlocks {
     public static final RegistryObject<Block> ALOE_ICE_CREAM_BLOCK = HELPER.createBlock("aloe_ice_cream_block", () -> new Block(Properties.ALOE_ICE_CREAM_BLOCK));
     public static final RegistryObject<Block> ALOE_CAKE_BLOCK = HELPER.createBlockNoItem("aloe_cake", () -> new FlavoredCakeBlock(PeculiarsItems.Foods.ALOE_CAKE, Properties.ALOE_CAKE));
 
-    public static final RegistryObject<Block> PASSION_FRUIT_MILKSHAKE_CAULDRON = HELPER.createBlockNoItem("passion_fruit_milkshake_cauldron", () -> new MilkshakeCauldronBlock(PeculiarsCauldronInteractions.PASSIONFRUIT_MILKSHAKE.map()));
+    public static final RegistryObject<Block> PASSION_FRUIT_MILKSHAKE_CAULDRON = HELPER.createBlockNoItem("passion_fruit_milkshake_cauldron", () -> new MilkshakeCauldronBlock(PeculiarsCauldronInteractions.PASSION_FRUIT_MILKSHAKE.map()));
     public static final RegistryObject<Block> PASSION_FRUIT_ICE_CREAM_BLOCK = HELPER.createBlock("passion_fruit_ice_cream_block", () -> new Block(Properties.PASSION_FRUIT_ICE_CREAM_BLOCK));
-    public static final RegistryObject<Block> PASSION_FRUIT_CAKE_BLOCK = HELPER.createBlockNoItem("passion_fruit_cake", () -> new FlavoredCakeBlock(PeculiarsItems.Foods.PASSIONFRUIT_CAKE, Properties.PASSION_FRUIT_CAKE));
+    public static final RegistryObject<Block> PASSION_FRUIT_CAKE_BLOCK = HELPER.createBlockNoItem("passion_fruit_cake", () -> new FlavoredCakeBlock(PeculiarsItems.Foods.PASSION_FRUIT_CAKE, Properties.PASSION_FRUIT_CAKE));
 
     static class Properties {
         public static final Block.Properties YUCCA_ICE_CREAM_BLOCK = Block.Properties.of().mapColor(MapColor.COLOR_LIGHT_GREEN).requiresCorrectToolForDrops().strength(0.2F).sound(SoundType.SNOW);

--- a/src/main/java/com/cosmicgelatin/peculiars/core/registry/PeculiarsItems.java
+++ b/src/main/java/com/cosmicgelatin/peculiars/core/registry/PeculiarsItems.java
@@ -29,9 +29,9 @@ public class PeculiarsItems {
     public static final RegistryObject<Item> ALOE_BERRY_SMOOTHIE = HELPER.createItem("aloe_berry_smoothie", () -> new HealingDrinkItem(2.0F, new Item.Properties().food(Foods.ALOE_BERRY_SMOOTHIE).stacksTo(16)));
     public static final RegistryObject<Item> ALOE_CAKE = HELPER.createItem("aloe_cake", () -> new BlockItem(PeculiarsBlocks.ALOE_CAKE_BLOCK.get(), new Item.Properties().stacksTo(1)));
 
-    public static final RegistryObject<Item> PASSIONFRUIT_ICE_CREAM = HELPER.createItem("passion_fruit_ice_cream", () -> new IceCreamItem(new Item.Properties().food(Foods.PASSIONFRUIT_ICE_CREAM).craftRemainder(Items.BOWL).stacksTo(1)));
-    public static final RegistryObject<Item> PASSIONFRUIT_MILKSHAKE = HELPER.createItem("passion_fruit_milkshake", () -> new MilkshakeItem(new Item.Properties().food(Foods.PASSIONFRUIT_MILKSHAKE).craftRemainder(Items.GLASS_BOTTLE).stacksTo(16)));
-    public static final RegistryObject<Item> PASSIONFRUIT_CAKE = HELPER.createItem("passion_fruit_cake", () -> new BlockItem(PeculiarsBlocks.PASSION_FRUIT_CAKE_BLOCK.get(), new Item.Properties().stacksTo(1)));
+    public static final RegistryObject<Item> PASSION_FRUIT_ICE_CREAM = HELPER.createItem("passion_fruit_ice_cream", () -> new IceCreamItem(new Item.Properties().food(Foods.PASSION_FRUIT_ICE_CREAM).craftRemainder(Items.BOWL).stacksTo(1)));
+    public static final RegistryObject<Item> PASSION_FRUIT_MILKSHAKE = HELPER.createItem("passion_fruit_milkshake", () -> new MilkshakeItem(new Item.Properties().food(Foods.PASSION_FRUIT_MILKSHAKE).craftRemainder(Items.GLASS_BOTTLE).stacksTo(16)));
+    public static final RegistryObject<Item> PASSION_FRUIT_CAKE = HELPER.createItem("passion_fruit_cake", () -> new BlockItem(PeculiarsBlocks.PASSION_FRUIT_CAKE_BLOCK.get(), new Item.Properties().stacksTo(1)));
 
     public static final RegistryObject<Item> TROPICAL_SALAD = HELPER.createItem("tropical_salad", () -> new BowlFoodItem(new Item.Properties().food(Foods.TROPICAL_SALAD).craftRemainder(Items.BOWL).stacksTo(1)));
 
@@ -47,12 +47,12 @@ public class PeculiarsItems {
         public static final FoodProperties ALOE_BERRY_SMOOTHIE = (new FoodProperties.Builder()).nutrition(3).saturationMod(0.6F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.RELIEF.get(), 600), 1.0F).build();
         public static final FoodProperties ALOE_CAKE = (new FoodProperties.Builder()).nutrition(1).saturationMod(0.1F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.RELIEF.get(), 200), 1.0F).build();
 
-        public static final FoodProperties PASSIONFRUIT_ICE_CREAM = (new FoodProperties.Builder()).nutrition(6).saturationMod(0.42F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 100, 2), 1.0F).build();
-        public static final FoodProperties PASSIONFRUIT_MILKSHAKE = NeapolitanItems.NeapolitanFoods.createMilkshake(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 200)).build();
-        public static final FoodProperties PASSIONFRUIT_CAKE = (new FoodProperties.Builder()).nutrition(1).saturationMod(0.1F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 100), 1.0F).build();
+        public static final FoodProperties PASSION_FRUIT_ICE_CREAM = (new FoodProperties.Builder()).nutrition(6).saturationMod(0.42F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 100, 2), 1.0F).build();
+        public static final FoodProperties PASSION_FRUIT_MILKSHAKE = NeapolitanItems.NeapolitanFoods.createMilkshake(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 200)).build();
+        public static final FoodProperties PASSION_FRUIT_CAKE = (new FoodProperties.Builder()).nutrition(1).saturationMod(0.1F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 100), 1.0F).build();
 
         public static final FoodProperties TROPICAL_SALAD = (new FoodProperties.Builder()).nutrition(6).saturationMod(1.1F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 100), 1.0F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.PERSISTENCE.get(), 200, 1), 1.0F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.RELIEF.get(), 400, 1), 1.0F).build();
 
-        public static final FoodProperties PASSIONFRUIT_TART = (new FoodProperties.Builder()).nutrition(4).saturationMod(0.6F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 100, 0), 1.0F).build();
+        public static final FoodProperties PASSION_FRUIT_TART = (new FoodProperties.Builder()).nutrition(4).saturationMod(0.6F).effect(() -> new MobEffectInstance(AtmosphericMobEffects.SPITTING.get(), 100, 0), 1.0F).build();
     }
 }

--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -28,20 +28,20 @@ description='''Addon for Neapolitan that adds new foods for all of the flavors i
 [[dependencies.peculiars]]
     modId="neapolitan"
     mandatory=true
-    versionRange="[5.0.0,)"
+    versionRange="[5.1.0,)"
     ordering="NONE"
     side="BOTH"
 
 [[dependencies.peculiars]]
     modId="blueprint"
     mandatory=true
-    versionRange="[7.1.0,)"
+    versionRange="[7.1.3,)"
     ordering="AFTER"
     side="BOTH"
 
 [[dependencies.peculiars]]
     modId="atmospheric"
     mandatory=false
-    versionRange="[6.0.0,)"
+    versionRange="[6.1.1,)"
     ordering="AFTER"
     side="BOTH"

--- a/src/main/resources/assets/peculiars/lang/en_us.json
+++ b/src/main/resources/assets/peculiars/lang/en_us.json
@@ -8,8 +8,8 @@
   "item.peculiars.aloe_jelly_slice": "Aloe Jelly Slice",
   "item.peculiars.aloe_berry_smoothie": "Aloe Berry Smoothie",
 
-  "item.peculiars.passion_fruit_ice_cream": "Passionfruit Ice Cream",
-  "item.peculiars.passion_fruit_milkshake": "Passionfruit Milkshake",
+  "item.peculiars.passion_fruit_ice_cream": "Passion Fruit Ice Cream",
+  "item.peculiars.passion_fruit_milkshake": "Passion Fruit Milkshake",
 
   "item.peculiars.tropical_salad": "Tropical Salad",
 
@@ -19,6 +19,6 @@
   "block.peculiars.aloe_cake": "Aloe Cake",
   "block.peculiars.aloe_ice_cream_block": "Aloe Ice Cream Block",
 
-  "block.peculiars.passion_fruit_cake": "Passionfruit Cake",
-  "block.peculiars.passion_fruit_ice_cream_block": "Passionfruit Ice Cream Block"
+  "block.peculiars.passion_fruit_cake": "Passion Fruit Cake",
+  "block.peculiars.passion_fruit_ice_cream_block": "Passion Fruit Ice Cream Block"
 }


### PR DESCRIPTION
This commit contains:

- Updates to the latest 1.20.1 versions of gradle dependencies (Blueprint, Neapolitan, Atmospheric)
- Consistency changes with Atmospheric for en_us translations: "Passionfruit" to "Passion Fruit" (closes #9)
- Consistency changes for variable names: "PASSIONFRUIT" to "PASSION_FRUIT"